### PR TITLE
feat: Load database configuration from JSON file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ tls/
 secret/
 .json
 config.json
+cmd/web/config.json

--- a/cmd/web/config.json.sample
+++ b/cmd/web/config.json.sample
@@ -1,0 +1,3 @@
+{
+    "dsn": "user:password@/database?parseTime=true"
+}


### PR DESCRIPTION
This change modifies the application to read the database DSN from a `config.json` file instead of a hardcoded command-line flag. This improves security by removing credentials from the source code and allows for easier configuration in different environments.

A sample configuration file `config.json.sample` is provided to guide the user in setting up their own configuration.

I had the general bits, but did not think to just chuck it all in json and call it a day. 